### PR TITLE
Repro without a reboot

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # minimal_example_for_sops_nix_659
 
-Run `rm -f nixos.qcow2 && nixos-shell --flake .#` login as root, run `reboot`, login again as root and run `ls -la /run`.
+Run `rm -f nixos.qcow2 && nixos-shell --flake .#`, login as root, and run `ls -la /run`.

--- a/flake.nix
+++ b/flake.nix
@@ -12,13 +12,9 @@
         modules = [
           {
             system.stateVersion = "24.05";
-          }
-          {
-            environment.etc."age-keys.txt".source = "${./age-keys.txt}";
-          }
-          inputs.sops-nix.nixosModules.sops
-          {
+
             imports = [
+              inputs.sops-nix.nixosModules.sops
               ./nix-sops.nix
             ];
           }

--- a/nix-sops.nix
+++ b/nix-sops.nix
@@ -1,9 +1,13 @@
-{config, pkgs, ...}:
+{config, ...}:
 
 {
-  sops.age.keyFile = "/etc/age-keys.txt";
+  nixos-shell.mounts.extraMounts = {
+    "/flake/" = ./.;
+  };
+
+  sops.age.keyFile = "/flake/age-keys.txt";
   sops.defaultSopsFile = ./secrets/main.yaml;
-  # disable importing host ssh keys
+  # Disable importing host ssh keys.
   sops.gnupg.sshKeyPaths = [];
 
   sops.secrets.example_key = {};


### PR DESCRIPTION
The only reason we needed a reboot is because the `environment.etc` stuff happens *after* sops-nix, so the first boot/activation fails due to a missing age key.

This gets the secret key into the vm using a nixos-shell mount, which gets things to fail on the very first try.